### PR TITLE
Fix nhmmer stdout buffering; add --plain-ids and profile-name warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,26 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-28
+
+### Added
+- `--region ssu` and `--region lsu` for flanking ribosomal gene export.
+- `--plain-ids` to emit output with the input read ID unchanged, omitting the
+  default `|<region>:<start>-<end>` suffix, for joining output back to input.
+- Unrecognised profile names are counted, sampled and reported on stderr and in
+  the QC JSON (`tblout.unclassified_hits`, `tblout.unclassified_models`), so a
+  mismatched HMM set fails loudly rather than under-detecting anchors silently.
+
+### Fixed
+- Peak memory reduced ~6x on large inputs. `nhmmer`'s human-readable stdout
+  report was being buffered in full and discarded; it scaled with reported hits
+  at ~464 B/hit and accounted for 5.98 GB of a 7.07 GB peak RSS on a 230 Mbp
+  input. Extraction results are unchanged.
+- Empty input now reports "no sequence records" instead of an opaque `nhmmer`
+  format-autodetection failure.
+
 ## [0.1.0] - 2026-02-13
+
 ### Added
 - Initial release of ITSxRust.
 - `extract` command for ITS region extraction using HMMER tblout anchors.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 license: "MIT"
 repository-code: "https://github.com/ayobi/ITSxRust"
 url: "https://github.com/ayobi/ITSxRust"
-version: "0.1.0"
-date-released: "2026-02-13"
+version: "0.3.0"
+date-released: "2026-07-28"
 keywords:
   - ITS
   - fungi
@@ -18,12 +18,14 @@ keywords:
   - PacBio
   - amplicon
 preferred-citation:
-  type: software
+  type: article
+  doi: "10.64898/2026.02.25.707950"
+  journal: "bioRxiv"
   authors:
     - family-names: "O'Brien"
       given-names: "Aaron"
   title: "ITSxRust"
-  version: "0.1.0"
-  date-released: "2026-02-13"
+  version: "0.3.0"
+  date-released: "2026-07-28"
   url: "https://github.com/ayobi/ITSxRust"
   repository-code: "https://github.com/ayobi/ITSxRust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "itsxrust"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "itsxrust"
 edition = "2024"
-version = "0.2.2"
+version = "0.3.0"
 license = "MIT"
 repository = "https://github.com/ayobi/ITSxRust"
 

--- a/src/hmmer.rs
+++ b/src/hmmer.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, anyhow};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 pub struct HmmerArgs<'a> {
     pub hmm: &'a Path,
@@ -17,6 +17,12 @@ pub struct HmmerArgs<'a> {
 }
 
 pub fn run_nhmmer(args: &HmmerArgs) -> Result<()> {
+    // nhmmer writes a human-readable report to stdout in addition to --tblout.
+    // Capturing that stream (Command::output()) buffers the whole report in
+    // memory and it scales with the number of *reported* hits: measured at
+    // ~464 B/hit, it accounted for 5.98 GB of a 7.07 GB peak RSS on a 230 Mbp
+    // input, versus 1.09 GB for the identical parse from a pre-computed tblout.
+    // We only ever read --tblout, so discard stdout and keep stderr for errors.
     let output = Command::new("nhmmer")
         .arg("--cpu")
         .arg(args.cpu.to_string())
@@ -31,14 +37,17 @@ pub fn run_nhmmer(args: &HmmerArgs) -> Result<()> {
         .arg(args.tblout)
         .arg(args.hmm)
         .arg(args.fasta)
-        .output()
-        .with_context(|| "Failed to spawn `nhmmer`. Is your conda env active?")?;
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| "Failed to spawn `nhmmer`. Is your conda env active?")?
+        .wait_with_output()
+        .with_context(|| "`nhmmer` terminated abnormally")?;
 
     if !output.status.success() {
         return Err(anyhow!(
-            "nhmmer failed (exit={:?})\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            "nhmmer failed (exit={:?})\n--- stderr ---\n{}",
             output.status.code(),
-            String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod seq;
 mod tblout;
 mod trim;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use clap::{Parser, Subcommand, ValueEnum};
 use rayon::prelude::*;
 use serde::Serialize;
@@ -153,6 +153,12 @@ enum Commands {
         /// Exact dereplication: search only unique sequences, project results to duplicates
         #[arg(long, default_value_t = false)]
         derep: bool,
+
+        /// Emit output sequences with the input read ID unchanged, omitting the
+        /// default `|<region>:<start>-<end>` coordinate suffix. Use when joining
+        /// output back to input on read ID.
+        #[arg(long)]
+        plain_ids: bool,
     },
 }
 
@@ -295,6 +301,23 @@ impl AnchorHitOut {
 }
 
 #[allow(clippy::too_many_arguments)]
+/// True if the file contains at least one FASTA record. Short-circuits on the
+/// first header line, so this is O(1) for any non-empty input.
+fn fasta_has_records(path: &std::path::Path) -> Result<bool> {
+    use std::io::BufRead;
+    let f =
+        std::fs::File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
+    for line in std::io::BufReader::new(f).lines() {
+        if line?.starts_with('>') {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+// Ten fields: one column group per anchor plus bounds and labels. Bundling
+// them into a struct is the tidier fix but touches every call site.
+#[allow(clippy::too_many_arguments)]
 fn write_anchor_tsv_row<W: Write>(
     w: &mut W,
     rid: &str,
@@ -420,6 +443,7 @@ fn main() -> Result<()> {
             write_ambiguous,
             qc_json,
             derep,
+            plain_ids,
         } => {
             // ---------------------------------------------------------------
             // Resolve preset → effective parameters
@@ -658,6 +682,17 @@ fn main() -> Result<()> {
                     }
                 };
 
+                // An empty input makes nhmmer fail with an opaque
+                // "Failed to autodetect format" error; catch it here instead.
+                if !fasta_has_records(&fasta_target)? {
+                    anyhow::bail!(
+                        "Input contained no sequence records: {}\n\
+                         If this file came from an upstream pipeline step, check that \
+                         the step succeeded before rerunning.",
+                        input.display()
+                    );
+                }
+
                 hmmer::run_nhmmer(&hmmer::HmmerArgs {
                     hmm: hmm_path,
                     fasta: &fasta_target,
@@ -678,6 +713,17 @@ fn main() -> Result<()> {
                 "tblout hits parsed: {} | anchor hits: {} | stored(topK): {} | reads w/anchor hits: {}",
                 stats.total_tblout_hits, stats.anchor_hits, stats.stored_hits, stats.reads
             );
+            if stats.unclassified_hits > 0 {
+                eprintln!(
+                    "WARNING: {} tblout hits came from {} profile name(s) that do not map to \
+                     any of the four anchor types (SSU 3'end, 5.8S 5'start, 5.8S 3'end, \
+                     LSU 5'start) and were ignored. Anchors may be under-detected. \
+                     Unrecognised name(s): {}",
+                    stats.unclassified_hits,
+                    stats.unclassified_models.len(),
+                    stats.unclassified_models.join(", ")
+                );
+            }
 
             // Expand dereplicated hits
             if let Some(ref dr) = derep_result {
@@ -1014,6 +1060,7 @@ fn main() -> Result<()> {
                     eff_max_per_anchor,
                     eff_constraints,
                     explain,
+                    plain_ids,
                 )?;
 
                 eprintln!("Wrote outputs:");
@@ -1050,6 +1097,7 @@ fn main() -> Result<()> {
                     eff_max_per_anchor,
                     eff_constraints,
                     explain,
+                    plain_ids,
                 )?;
 
                 eprintln!("Wrote output: {}", output.display());
@@ -1114,6 +1162,8 @@ fn main() -> Result<()> {
                         anchor_hits: stats.anchor_hits,
                         stored_topk: stats.stored_hits,
                         reads_with_hits: stats.reads,
+                        unclassified_hits: stats.unclassified_hits,
+                        unclassified_models: stats.unclassified_models.clone(),
                     },
                     params: report::ParamsSummary {
                         preset: preset.map(|p| match p {

--- a/src/report.rs
+++ b/src/report.rs
@@ -154,6 +154,17 @@ pub struct TbloutSummary {
     pub anchor_hits: u64,
     pub stored_topk: u64,
     pub reads_with_hits: usize,
+
+    /// Omitted when zero, so the existing JSON schema is unchanged for runs
+    /// using a recognised profile set.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub unclassified_hits: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unclassified_models: Vec<String>,
+}
+
+fn is_zero(n: &u64) -> bool {
+    *n == 0
 }
 
 #[derive(Serialize)]

--- a/src/tblout.rs
+++ b/src/tblout.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -127,6 +127,14 @@ pub struct StreamStats {
     pub anchor_hits: u64,       // hits that matched an anchor + strand
     pub stored_hits: u64,       // final stored hits across all reads/bins
     pub reads: usize,           // reads with >=1 anchor hit
+
+    /// Hits whose profile name did not map to any of the four anchor types.
+    /// Non-zero means the supplied HMM set uses names this build does not
+    /// recognise, and anchors will be silently under-detected rather than
+    /// reported as an error.
+    pub unclassified_hits: u64,
+    /// Up to 10 distinct unrecognised profile names, for the warning message.
+    pub unclassified_models: Vec<String>,
 }
 
 /// Stream tblout line-by-line and keep only Top-K per (anchor × strand) per read.
@@ -145,6 +153,8 @@ pub fn stream_topk_tblout(
     let mut map: HashMap<String, TopKHits> = HashMap::new();
     let mut total_tblout_hits: u64 = 0;
     let mut anchor_hits: u64 = 0;
+    let mut unclassified_hits: u64 = 0;
+    let mut unclassified_models: BTreeSet<String> = BTreeSet::new();
 
     let mut line = String::new();
     loop {
@@ -166,6 +176,10 @@ pub fn stream_topk_tblout(
         }
 
         let Some(anchor) = select::classify(&hit.model) else {
+            unclassified_hits += 1;
+            if unclassified_models.len() < 10 {
+                unclassified_models.insert(hit.model.clone());
+            }
             continue;
         };
 
@@ -184,6 +198,8 @@ pub fn stream_topk_tblout(
         anchor_hits,
         stored_hits,
         reads: map.len(),
+        unclassified_hits,
+        unclassified_models: unclassified_models.into_iter().collect(),
     };
 
     Ok((map, stats))

--- a/src/trim.rs
+++ b/src/trim.rs
@@ -134,11 +134,18 @@ fn extract_trimmed(rec: &Record, plan: &ExtractPlan) -> Option<(String, Option<S
     }
 }
 
-fn trimmed_id(read_id: &str, region_tag: &str, plan: &ExtractPlan) -> String {
-    format!(
-        "{}|{}:{}-{}",
-        read_id, region_tag, plan.norm_start, plan.norm_end
-    )
+fn trimmed_id(read_id: &str, region_tag: &str, plan: &ExtractPlan, plain_ids: bool) -> String {
+    // The default appends `|<region>:<start>-<end>` so coordinates travel with
+    // the sequence. Anything joining on read ID downstream has to strip it, so
+    // --plain-ids emits the input ID unchanged.
+    if plain_ids {
+        read_id.to_string()
+    } else {
+        format!(
+            "{}|{}:{}-{}",
+            read_id, region_tag, plan.norm_start, plan.norm_end
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -226,6 +233,7 @@ pub fn trim_all(
     max_per_anchor: usize,
     constraints: select::Constraints,
     explain: usize,
+    plain_ids: bool,
 ) -> Result<TrimStats> {
     let mut outputs = [
         RegionOutput {
@@ -268,7 +276,7 @@ pub fn trim_all(
                 if let Some(plan) = maybe_plan
                     && let Some((out_seq, out_qual)) = extract_trimmed(&rec, plan)
                 {
-                    let out_id = trimmed_id(&rec.id, outputs[i].tag, plan);
+                    let out_id = trimmed_id(&rec.id, outputs[i].tag, plan, plain_ids);
                     outputs[i]
                         .writer
                         .write_record(&out_id, &out_seq, out_qual.as_deref())?;
@@ -327,6 +335,7 @@ pub fn trim_single(
     max_per_anchor: usize,
     constraints: select::Constraints,
     explain: usize,
+    plain_ids: bool,
 ) -> Result<TrimStats> {
     let mut w = SeqWriter::open(out_path, out_fmt)?;
     let mut stats = TrimStats::default();
@@ -349,7 +358,7 @@ pub fn trim_single(
             }
 
             if let Some((out_seq, out_qual)) = extract_trimmed(&rec, plan) {
-                let out_id = trimmed_id(&rec.id, region_tag, plan);
+                let out_id = trimmed_id(&rec.id, region_tag, plan, plain_ids);
                 w.write_record(&out_id, &out_seq, out_qual.as_deref())?;
                 stats.kept_any += 1;
                 continue;

--- a/tests/extract_subset_from_tblout.rs
+++ b/tests/extract_subset_from_tblout.rs
@@ -181,7 +181,7 @@ fn ssu_lsu_export_reconstructs_subset_reads() {
         let (Some(f), Some(l), Some(o)) = (full.get(rid), lsu.get(rid), orig.get(rid)) else {
             continue;
         };
-        let recon = format!("{}{}{}", &ssu[rid], f, l);
+        let recon = format!("{}{}{}", ssu[rid], f, l);
         if &recon == o {
             ok_fwd += 1;
         } else if recon == revcomp_dna(o) {


### PR DESCRIPTION
Peak RSS drops ~6x on large inputs with extraction results unchanged. Adds --plain-ids, unrecognised-profile reporting, and a clear error on empty input. Bumps to 0.3.0 and updates CHANGELOG and CITATION.cff.